### PR TITLE
データの取得時間を SPIKE Prime のラージハブの周波数に合わせる

### DIFF
--- a/src/components/organisms/MotionSensorFloatingButton/MotionSensorFloatingButton.hooks.tsx
+++ b/src/components/organisms/MotionSensorFloatingButton/MotionSensorFloatingButton.hooks.tsx
@@ -135,7 +135,7 @@ export const useMotionSensorFloatingButton = (
         };
       });
     },
-    isTimerStart ? 1000 : null,
+    isTimerStart ? 10 : null,
     mobileContext,
   );
 


### PR DESCRIPTION
### 関連する Issue
<!-- close #XXX で書くとリンクできて楽です -->
#22 

### やったこと
<!-- このプルリクで何をしたのか？ -->
- SPIKE Prime の周波数に合わせるためにデータの取得時間を 10ms に変更

### やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- 特になし

### できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- 特になし

### できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- 特になし

### 動作のスクリーンショット
<!-- スクリーンショットか動画でお願いします -->
- 特になし

### その他
<!-- レビューに関して何か気になることや注意してほしい点を書く -->
